### PR TITLE
GCS deployment workflow

### DIFF
--- a/.github/workflows/deploy-gcs.yml
+++ b/.github/workflows/deploy-gcs.yml
@@ -1,0 +1,35 @@
+name: Deploy to Google Cloud Storage
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy-gcs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Google auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCS_CREDENTIALS }}
+
+      - name: Setup gcloud / gsutil
+        uses: google-github-actions/setup-gcloud@master
+
+      - name: Publish repo contents
+        env:
+          GCS_BUCKET: ${{ secrets.GCS_BUCKET }}
+        run: |
+          gsutil -m rsync -r src gs://$GCS_BUCKET


### PR DESCRIPTION
Simple workflow that runs on `workflow_dispatch` or pushes to `main`:

1. Checkout repository
2. Auth to Google Cloud with GitHub Secrets
3. Setup `gsutil`
4. Use `gsutil rsync` to sync contents of `src/` with bucket

~**BLOCKED**: we need the DNS entries verified before we can create the target bucket.~

DNS entries are created, and target bucket is created.