### PR TITLE
Feat: make license explicit

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,234 +1,337 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta
+      name="description"
+      content="GTFS data from the California Integrated Travel Project (Cal-ITP)"
+    />
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <meta name="description" content="GTFS data from the California Integrated Travel Project (Cal-ITP)">
+    <title>GTFS data from Cal-ITP</title>
 
-  <title>GTFS data from Cal-ITP</title>
+    <link href="styles.css" rel="stylesheet" type="text/css" />
 
-  <link href="styles.css" rel="stylesheet" type="text/css" />
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-EQTSM86LYE"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-EQTSM86LYE"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() { dataLayer.push(arguments); }
-    gtag('js', new Date());
+      gtag("config", "G-EQTSM86LYE");
+    </script>
+  </head>
 
-    gtag('config', 'G-EQTSM86LYE');
-  </script>
-</head>
-
-<body>
-  <h1>GTFS data from Cal-ITP</h1>
-  <table>
+  <body>
+    <h1>GTFS data from Cal-ITP</h1>
+    <table>
       <thead>
-          <tr>
-              <th>Service</th>
-              <th>Download Link</th>
-              <th>Date Uploaded</th>
-          </tr>
+        <tr>
+          <th>Service</th>
+          <th>Download Link</th>
+          <th>Date Uploaded</th>
+        </tr>
       </thead>
       <tbody>
         <tr>
-            <td>Eastern Sierra Bishop and Lone Pine Dial-a-Ride</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/EasternSierraBishopLonePineFlex.zip">https://gtfs.calitp.org/production/EasternSierraBishopLonePineFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Eastern Sierra Bishop and Lone Pine Dial-a-Ride</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/EasternSierraBishopLonePineFlex.zip"
+              >https://gtfs.calitp.org/production/EasternSierraBishopLonePineFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Guadalupe Flyer Paratransit</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/GuadalupeFlyerParatransitFlex.zip">https://gtfs.calitp.org/production/GuadalupeFlyerParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Guadalupe Flyer Paratransit</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/GuadalupeFlyerParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/GuadalupeFlyerParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Humboldt Transit Authority Dial-a-Ride</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/HumboldtTransitAuthorityDialARideFlex.zip">https://gtfs.calitp.org/production/HumboldtTransitAuthorityDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Humboldt Transit Authority Dial-a-Ride</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/HumboldtTransitAuthorityDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/HumboldtTransitAuthorityDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Laguna Beach Local</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/LagunaBeachTransitLocalFlex.zip">https://gtfs.calitp.org/production/LagunaBeachTransitLocalFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Laguna Beach Local</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/LagunaBeachTransitLocalFlex.zip"
+              >https://gtfs.calitp.org/production/LagunaBeachTransitLocalFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Lassen Rural Bus Dial-a-Ride and Route Deviation</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/LassenRuralBusandDialARideFlex.zip">https://gtfs.calitp.org/production/LassenRuralBusandDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Lassen Rural Bus Dial-a-Ride and Route Deviation</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/LassenRuralBusandDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/LassenRuralBusandDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Manteca Transit Dial-a-Ride Paratransit</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/MantecaTransitParatransitFlex.zip">https://gtfs.calitp.org/production/MantecaTransitParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Manteca Transit Dial-a-Ride Paratransit</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/MantecaTransitParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/MantecaTransitParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>MOVE Stanislaus Vetsvan</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip">https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>MOVE Stanislaus Vetsvan</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip"
+              >https://gtfs.calitp.org/production/MOVEStanislausVetsvanFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Placer County Transit Dial-a-Ride</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/PlacerCountyDialARideFlex.zip">https://gtfs.calitp.org/production/PlacerCountyDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Placer County Transit Dial-a-Ride</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/PlacerCountyDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/PlacerCountyDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                Redwood Coast Transit Del Norte Dial-a-Ride and Route
-                Deviation
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/RedwoodCoastDelNorteFlex.zip">https://gtfs.calitp.org/production/RedwoodCoastDelNorteFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            Redwood Coast Transit Del Norte Dial-a-Ride and Route Deviation
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/RedwoodCoastDelNorteFlex.zip"
+              >https://gtfs.calitp.org/production/RedwoodCoastDelNorteFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                San Benito County Express Dial-a-Ride, Paratransit, and
-                On-Demand
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/SanBenitoCountyExpressDialARideParatransitOnDemandFlex.zip">https://gtfs.calitp.org/production/SanBenitoCountyExpressDialARideParatransitOnDemandFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            San Benito County Express Dial-a-Ride, Paratransit, and On-Demand
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/SanBenitoCountyExpressDialARideParatransitOnDemandFlex.zip"
+              >https://gtfs.calitp.org/production/SanBenitoCountyExpressDialARideParatransitOnDemandFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>San Joaquin RTD Dial-a-Ride and Van Go!</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip">https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>San Joaquin RTD Dial-a-Ride and Van Go!</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip"
+              >https://gtfs.calitp.org/production/SanJoaquinRTDDialARideandVanGoFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                Stanislaus Regional Transit Authority Dial-a-Ride for
-                Modesto, Newman, Oakdale, Patterson, and Riverbank
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip">https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            Stanislaus Regional Transit Authority Dial-a-Ride for Modesto,
+            Newman, Oakdale, Patterson, and Riverbank
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip"
+              >https://gtfs.calitp.org/production/StanRTAModestoNewmanOakdalePattersomandRiverbankFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                Tahoe Truckee Regional Transportation TART Connect,
-                Dial-a-Ride, and Placer TART Paratransit
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/TahoeTruckeeRegionalTransportationTARTConnectDialARidePlacerTARTParatransitFlex.zip">https://gtfs.calitp.org/production/TahoeTruckeeRegionalTransportationTARTConnectDialARidePlacerTARTParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            Tahoe Truckee Regional Transportation TART Connect, Dial-a-Ride, and
+            Placer TART Paratransit
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/TahoeTruckeeRegionalTransportationTARTConnectDialARidePlacerTARTParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/TahoeTruckeeRegionalTransportationTARTConnectDialARidePlacerTARTParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                Thousand Oaks Transit Dial-a-Ride, Paratransit, and
-                Intercity Connect
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/ThousandOaksDialARideParatransitandConnectFlex.zip">https://gtfs.calitp.org/production/ThousandOaksDialARideParatransitandConnectFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            Thousand Oaks Transit Dial-a-Ride, Paratransit, and Intercity
+            Connect
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/ThousandOaksDialARideParatransitandConnectFlex.zip"
+              >https://gtfs.calitp.org/production/ThousandOaksDialARideParatransitandConnectFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Tracy TRACER Plus and Paratransit</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip">https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Tracy TRACER Plus and Paratransit</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/TracyTRACERPlusandParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>
-                Tulare County Area Transit Dial-a-Ride and Route Deviation
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/TulareCountyAreaTransitandDialARideFlex.zip">https://gtfs.calitp.org/production/TulareCountyAreaTransitandDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Tulare County Area Transit Dial-a-Ride and Route Deviation</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/TulareCountyAreaTransitandDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/TulareCountyAreaTransitandDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Turlock Transit Paratransit</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/TurlockTransitDialARideFlex.zip">https://gtfs.calitp.org/production/TurlockTransitDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Turlock Transit Paratransit</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/TurlockTransitDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/TurlockTransitDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Union City Transit Paratransit</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/UnionCityParatransitFlex.zip">https://gtfs.calitp.org/production/UnionCityParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Union City Transit Paratransit</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/UnionCityParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/UnionCityParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Valley Express Dial-a-Ride</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/ValleyExpressDialARideFlex.zip">https://gtfs.calitp.org/production/ValleyExpressDialARideFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>Valley Express Dial-a-Ride</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/ValleyExpressDialARideFlex.zip"
+              >https://gtfs.calitp.org/production/ValleyExpressDialARideFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
         <tr>
-            <td>Wasco Dial-a-Ride</td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/WascoDialaRideFlex.zip">https://gtfs.calitp.org/production/WascoDialaRideFlex.zip</a>
-            </td>
-            <td>January 13, 2022</td>
+          <td>Wasco Dial-a-Ride</td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/WascoDialaRideFlex.zip"
+              >https://gtfs.calitp.org/production/WascoDialaRideFlex.zip</a
+            >
+          </td>
+          <td>January 13, 2022</td>
         </tr>
         <tr>
-            <td>
-                WestCAT Paratransit, Senior Dial-a-Ride, and East Bay
-                Paratransit
-            </td>
-            <td>
-                <a target="_blank" href="https://gtfs.calitp.org/production/WestCATSeniorDialARideandParatransitFlex.zip">https://gtfs.calitp.org/production/WestCATSeniorDialARideandParatransitFlex.zip</a>
-            </td>
-            <td>October 24, 2022</td>
+          <td>
+            WestCAT Paratransit, Senior Dial-a-Ride, and East Bay Paratransit
+          </td>
+          <td>
+            <a
+              target="_blank"
+              href="https://gtfs.calitp.org/production/WestCATSeniorDialARideandParatransitFlex.zip"
+              >https://gtfs.calitp.org/production/WestCATSeniorDialARideandParatransitFlex.zip</a
+            >
+          </td>
+          <td>October 24, 2022</td>
         </tr>
       </tbody>
-  </table>
+    </table>
 
-  <h2>Test data for developers</h2>
-  <p>The following datasets are provided for developer test purposes only. They do not reflect actual services and are not intended for any other use.</p>
-  <table>
+    <h2>Test data for developers</h2>
+    <p>
+      The following datasets are provided for developer test purposes only. They
+      do not reflect actual services and are not intended for any other use.
+    </p>
+    <table>
       <thead>
-          <tr>
-              <th>Service</th>
-              <th>Download Link</th>
-              <th>Date Uploaded</th>
-          </tr>
+        <tr>
+          <th>Service</th>
+          <th>Download Link</th>
+          <th>Date Uploaded</th>
+        </tr>
       </thead>
       <tbody>
         <tr>
-            <td>TestFlex1</td>
-            <td><a target="blank" href="https://gtfs.calitp.org/test/TestFlex1.zip">https://gtfs.calitp.org/test/TestFlex1.zip</a></td>
-            <td>July 15, 2022</td>
+          <td>TestFlex1</td>
+          <td>
+            <a target="blank" href="https://gtfs.calitp.org/test/TestFlex1.zip"
+              >https://gtfs.calitp.org/test/TestFlex1.zip</a
+            >
+          </td>
+          <td>July 15, 2022</td>
         </tr>
         <tr>
-            <td>TestFlex2</td>
-            <td><a target="blank" href="https://gtfs.calitp.org/test/TestFlex2.zip">https://gtfs.calitp.org/test/TestFlex2.zip</a></td>
-            <td>July 15, 2022</td>
+          <td>TestFlex2</td>
+          <td>
+            <a target="blank" href="https://gtfs.calitp.org/test/TestFlex2.zip"
+              >https://gtfs.calitp.org/test/TestFlex2.zip</a
+            >
+          </td>
+          <td>July 15, 2022</td>
         </tr>
         <tr>
-            <td>TestFlex3</td>
-            <td><a target="blank" href="https://gtfs.calitp.org/test/TestFlex3.zip">https://gtfs.calitp.org/test/TestFlex3.zip</a></td>
-            <td>July 15, 2022</td>
+          <td>TestFlex3</td>
+          <td>
+            <a target="blank" href="https://gtfs.calitp.org/test/TestFlex3.zip"
+              >https://gtfs.calitp.org/test/TestFlex3.zip</a
+            >
+          </td>
+          <td>July 15, 2022</td>
         </tr>
       </tbody>
-  </table>
-</body>
-
+    </table>
+  </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -333,5 +333,13 @@
         </tr>
       </tbody>
     </table>
+
+    <h2>License</h2>
+    <p>
+      All data on this site is provided and licensed under the terms of the
+      <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">
+        Creative Commons Attribution 4.0 International (CC BY 4.0)</a
+      >.
+    </p>
   </body>
 </html>


### PR DESCRIPTION
The data is licensed under CC-BY-4 as noted in the [README](https://github.com/cal-itp/gtfs.calitp.org/blob/main/README.md#license).

This PR just makes the license explicit on the webpage itself.