### PR TITLE
Fix: Netlify preview deploys

### DIFF
--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Netlify CLI
-      run: npm install -g netlify-cli
+      run: npm install -g netlify-cli@17.x.x
 
     - name: Deploy Preview to Netlify
       run: |

--- a/.github/workflows/site-preview.yml
+++ b/.github/workflows/site-preview.yml
@@ -18,11 +18,10 @@ jobs:
     - name: Deploy Preview to Netlify
       run: |
         netlify deploy \
+          --alias="gtfs-calitp-org-${{ github.event.number }}" \
+          --auth=${{ secrets.NETLIFY_AUTH_TOKEN }} \
           --dir="src" \
-          --alias="gtfs-calitp-org-${{ github.event.number }}"
-      env:
-        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PREVIEW_APP_SITE_ID }}
+          --site=${{ secrets.NETLIFY_PREVIEW_APP_SITE_ID }}
 
     - name: Add netlify link PR comment
       uses: actions/github-script@v7


### PR DESCRIPTION
Netlify previews have continued to work in this repo, where they have been failing elsewhere e.g. [`benefits`](/cal-itp/benefits) and [`operational-data-standard`](/cal-itp/operational-data-standard).

I'm just applying the same fix here that I did to the other repos to normalize how these previews are generated.